### PR TITLE
블로그 등록 수정 삭제 단일조회 #32

### DIFF
--- a/src/main/java/com/openvelog/openvelogbe/blog/controller/BlogController.java
+++ b/src/main/java/com/openvelog/openvelogbe/blog/controller/BlogController.java
@@ -1,0 +1,63 @@
+package com.openvelog.openvelogbe.blog.controller;
+
+import com.openvelog.openvelogbe.blog.dto.BlogRequestDto;
+import com.openvelog.openvelogbe.blog.dto.BlogResponseDto;
+import com.openvelog.openvelogbe.blog.service.BlogService;
+import com.openvelog.openvelogbe.common.dto.ApiResponse;
+import com.openvelog.openvelogbe.common.security.UserDetailsImpl;
+import com.openvelog.openvelogbe.member.dto.MemberResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Tag(name = "blog")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/blogs")
+public class BlogController {
+    private final BlogService blogService;
+
+    @PostMapping
+    @Operation(summary = "블로그 등록", description = "블로그 등록")
+    public ApiResponse<BlogResponseDto> createBlog(
+            @RequestBody @Valid BlogRequestDto.BlogAdd dto,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ApiResponse.successOf(HttpStatus.CREATED, blogService.createBlog(dto, userDetails.getUser()));
+    }
+
+    @DeleteMapping("/{blogId}")
+    @Operation(summary = "블로그 삭제", description = "블로그 삭제")
+    public ApiResponse<BlogResponseDto> deleteBlog(
+            @PathVariable Long blogId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        blogService.deleteBlog(blogId, userDetails.getUser());
+        return ApiResponse.successOf(HttpStatus.OK, null);
+    }
+
+    @PutMapping("/{blogId}")
+    @Operation(summary = "블로그 수정", description = "블로그 수정")
+    public ApiResponse<BlogResponseDto> updateBlog(
+            @PathVariable Long blogId,
+            @RequestBody @Valid BlogRequestDto.BlogUpdate dto,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ApiResponse.successOf(HttpStatus.OK, blogService.updateBlog(blogId, dto, userDetails.getUser()));
+    }
+
+
+
+    @GetMapping("/{blogId}")
+    @SecurityRequirements()
+    @Operation(summary = "블로그 조회", description = "블로그 조회")
+    public ApiResponse<BlogResponseDto> getBlog(
+            @PathVariable Long blogId) {
+        return ApiResponse.successOf(HttpStatus.OK, blogService.getBlog(blogId));
+    }
+
+}

--- a/src/main/java/com/openvelog/openvelogbe/blog/dto/BlogRequestDto.java
+++ b/src/main/java/com/openvelog/openvelogbe/blog/dto/BlogRequestDto.java
@@ -1,0 +1,41 @@
+package com.openvelog.openvelogbe.blog.dto;
+
+import com.openvelog.openvelogbe.common.entity.Board;
+import com.openvelog.openvelogbe.common.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.persistence.*;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class BlogRequestDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class BlogAdd {
+
+        @NotBlank
+        @Size(min = 3, max = 30, message = "제목은 3자 이상 30자 이하이여야합니다.")
+        private String title;
+
+        @NotBlank
+        private String introduce;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class BlogUpdate {
+
+        @NotBlank
+        @Size(min = 3, max = 30, message = "제목은 3자 이상 30자 이하이여야합니다.")
+        private String title;
+
+        @NotBlank
+        private String introduce;
+    }
+}

--- a/src/main/java/com/openvelog/openvelogbe/blog/dto/BlogResponseDto.java
+++ b/src/main/java/com/openvelog/openvelogbe/blog/dto/BlogResponseDto.java
@@ -1,0 +1,61 @@
+package com.openvelog.openvelogbe.blog.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.openvelog.openvelogbe.common.entity.Blog;
+import com.openvelog.openvelogbe.common.entity.Board;
+import com.openvelog.openvelogbe.common.entity.Member;
+import com.openvelog.openvelogbe.member.dto.MemberResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+
+import javax.persistence.*;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlogResponseDto {
+
+    @Schema(type = "integer", example = "2")
+    private Long id;
+
+    @Schema(example = "블로그 타이틀")
+    private String title;
+
+    @Schema(example = "블로그 소개글")
+    private String introduce;
+
+    @Schema(example = "블로그 주인")
+    private MemberResponseDto member;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static BlogResponseDto of(Blog blog) {
+
+        BlogResponseDtoBuilder builder = builder()
+                .id(blog.getId())
+                .title(blog.getTitle())
+                .introduce(blog.getIntroduce())
+                .createdAt(blog.getCreatedAt())
+                .modifiedAt(blog.getModifiedAt());
+
+        return builder.build();
+    }
+
+}
+

--- a/src/main/java/com/openvelog/openvelogbe/blog/service/BlogService.java
+++ b/src/main/java/com/openvelog/openvelogbe/blog/service/BlogService.java
@@ -1,0 +1,64 @@
+package com.openvelog.openvelogbe.blog.service;
+
+import com.openvelog.openvelogbe.blog.dto.BlogRequestDto;
+import com.openvelog.openvelogbe.blog.dto.BlogResponseDto;
+import com.openvelog.openvelogbe.common.dto.ErrorMessage;
+import com.openvelog.openvelogbe.common.entity.Blog;
+import com.openvelog.openvelogbe.common.entity.Member;
+import com.openvelog.openvelogbe.common.repository.BlogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+    private final BlogRepository blogRepository;
+
+    @Transactional
+    public BlogResponseDto createBlog(BlogRequestDto.BlogAdd dto, Member member) {
+        Blog blog = Blog.create(dto, member);
+
+        return BlogResponseDto.of(blogRepository.save(blog));
+    }
+
+    @Transactional
+    public BlogResponseDto updateBlog(Long blogId, BlogRequestDto.BlogUpdate dto, Member member) {
+        Blog blog = blogRepository.findById(blogId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorMessage.NO_BLOG.getMessage())
+        );
+
+        if (!blog.getMember().getId().equals(member.getId())) {
+            throw new EntityNotFoundException(ErrorMessage.ACCESS_DENIED.getMessage());
+        }
+
+        blog.update(dto);
+
+        return BlogResponseDto.of(blog);
+    }
+
+    @Transactional
+    public void deleteBlog(Long blogId, Member member) {
+
+        Blog blog = blogRepository.findById(blogId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorMessage.NO_BLOG.getMessage())
+        );
+
+        if (!blog.getMember().getId().equals(member.getId())) {
+            throw new EntityNotFoundException(ErrorMessage.ACCESS_DENIED.getMessage());
+        }
+
+        blogRepository.delete(blog);
+    }
+
+    @Transactional(readOnly = true)
+    public BlogResponseDto getBlog(Long blogId) {
+        Blog blog = blogRepository.findByIdWithBoardsJPQL(blogId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorMessage.NO_BLOG.getMessage())
+        );
+
+        return BlogResponseDto.of(blog);
+    }
+}

--- a/src/main/java/com/openvelog/openvelogbe/common/config/SwaggerConfig.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.openvelog.openvelogbe.common.config;
 
+import com.openvelog.openvelogbe.common.jwt.JwtUtil;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -20,7 +21,7 @@ class SwaggerConfig {
                 .description("API Description");
 
         // SecuritySecheme명
-        String jwtSchemeName = "Authorization";
+        String jwtSchemeName = "jwtAuth";
         // API 요청헤더에 인증정보 포함
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
         // SecuritySchemes 등록

--- a/src/main/java/com/openvelog/openvelogbe/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/config/WebSecurityConfig.java
@@ -63,6 +63,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
                 .antMatchers(HttpMethod.GET, "/api/health-check").permitAll()
                 .antMatchers("/api/members/signup").permitAll()
                 .antMatchers("/api/members/login").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/blogs/{blogId}").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 // JWT 인증/인가를 사용하기 위한 설정

--- a/src/main/java/com/openvelog/openvelogbe/common/dto/ErrorMessage.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/dto/ErrorMessage.java
@@ -17,7 +17,8 @@ public enum ErrorMessage {
     USERID_DUPLICATION("userid가 중복됐습니다."),
     WRONG_USERNAME("username이 일치하지 않습니다."),
     WRONG_PASSWORD("패스워드가 틀렸습니다."),
-    WRONG_JWT_TOKEN("JWT Token이 잘못되었습니다.");
+    WRONG_JWT_TOKEN("JWT Token이 잘못되었습니다."),
+    NO_BLOG("블로그가 없습니다.");
 
     private final String message;
 

--- a/src/main/java/com/openvelog/openvelogbe/common/entity/Blog.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/entity/Blog.java
@@ -1,6 +1,10 @@
 package com.openvelog.openvelogbe.common.entity;
 
 
+import com.openvelog.openvelogbe.blog.dto.BlogRequestDto;
+import com.openvelog.openvelogbe.member.dto.SignupRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +14,8 @@ import java.util.Set;
 
 @Entity(name = "blogs")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class Blog extends Timestamped {
 
@@ -29,4 +35,17 @@ public class Blog extends Timestamped {
     @OneToMany(mappedBy = "blog")
     private Set<Board> boards = new LinkedHashSet<>();
 
+
+    public static Blog create(BlogRequestDto.BlogAdd dto, Member member) {
+        return builder()
+                .title(dto.getTitle())
+                .introduce(dto.getIntroduce())
+                .member(member)
+                .build();
+    }
+
+    public void update(BlogRequestDto.BlogUpdate dto) {
+        this.title = dto.getTitle();
+        this.introduce = dto.getIntroduce();
+    }
 }

--- a/src/main/java/com/openvelog/openvelogbe/common/repository/BlogRepository.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/repository/BlogRepository.java
@@ -1,7 +1,14 @@
 package com.openvelog.openvelogbe.common.repository;
 
 import com.openvelog.openvelogbe.common.entity.Blog;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface BlogRepository extends JpaRepository<Blog, Long> {
+
+    @Query("select distinct b from blogs b left join fetch b.boards where b.id = :blogId")
+    Optional<Blog> findByIdWithBoardsJPQL(Long blogId);
 }


### PR DESCRIPTION
feat : 블로그 등록 수정 삭제 단일조회 #32

blog등록, 수정, 삭제, 단일 조회 api추가, NO_BLOG에러메시지 추가, .antMatchers(HttpMethod.GET, "/api/blogs/{blogId}").permitAll()추가