### PR TITLE
#51 블로그 삭제시 게시판 null처리

### DIFF
--- a/src/main/java/com/openvelog/openvelogbe/blog/dto/BlogResponseDto.java
+++ b/src/main/java/com/openvelog/openvelogbe/blog/dto/BlogResponseDto.java
@@ -44,8 +44,13 @@ public class BlogResponseDto {
                 .title(blog.getTitle())
                 .introduce(blog.getIntroduce())
                 .createdAt(blog.getCreatedAt())
-                .boards(blog.getBoards().stream().map(BoardResponseDto::of).collect(Collectors.toList()))
                 .modifiedAt(blog.getModifiedAt());
+
+        if (blog.getBoards() != null) {
+            builder.boards(blog.getBoards().stream().map(BoardResponseDto::of).collect(Collectors.toList()));
+        }
+
+
 
         return builder.build();
     }

--- a/src/main/java/com/openvelog/openvelogbe/common/entity/Blog.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/entity/Blog.java
@@ -48,4 +48,9 @@ public class Blog extends Timestamped {
         this.title = dto.getTitle();
         this.introduce = dto.getIntroduce();
     }
+
+    @PreRemove
+    private void blogIdSetBullAtBoard() {
+        this.getBoards().forEach(Board::setBlogNull);
+    }
 }

--- a/src/main/java/com/openvelog/openvelogbe/common/entity/Board.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/entity/Board.java
@@ -31,6 +31,10 @@ public class Board extends Timestamped {
     @ManyToOne(fetch = FetchType.LAZY)
     private Blog blog;
 
+    public void setBlogNull() {
+        this.blog = null;
+    }
+
     public void update(BoardRequestDto.BoardUpdate dto) {
         this.title = dto.getTitle();
         this.content = dto.getContent();
@@ -43,5 +47,6 @@ public class Board extends Timestamped {
                 .blog(blog)
                 .build();
     }
+
 
 }


### PR DESCRIPTION
fix : of에서 boards가 null일때 처리 #51

Blog의 boards가 null이 아닐때만 boards맵핑

feat : 블로그 삭제시 게시판의 blogId null처리 #51

블로그 삭제시 게시판의 blogId null처리, @PreRemve blogIdSetBullAtBoard