### PR TITLE
#153 kafka로 검색 로그 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,11 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-rest-client:1.2.1'
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
+    //kafka
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+    implementation 'org.apache.kafka:kafka-clients:3.4.0'
+    implementation 'org.springframework.kafka:spring-kafka'
+
 
     // AWS s3
 //    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/com/openvelog/openvelogbe/common/config/KafkaConfig.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/config/KafkaConfig.java
@@ -1,0 +1,46 @@
+package com.openvelog.openvelogbe.common.config;
+
+import com.openvelog.openvelogbe.common.entity.SearchLog;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConfig {
+    private final KafkaProperties properties;
+
+    @Bean
+    public ConsumerFactory<String, SearchLog> consumerFactory() {
+        JsonDeserializer<SearchLog> deserializer = new JsonDeserializer<>(SearchLog.class);
+        deserializer.setUseTypeMapperForKey(true);
+        return new DefaultKafkaConsumerFactory<>(properties.buildConsumerProperties(), new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, SearchLog> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, SearchLog> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setBatchListener(true);
+        return factory;
+    }
+
+    @Bean
+    public ProducerFactory<String, SearchLog> producerFactory() {
+        JsonSerializer<SearchLog> serializer = new JsonSerializer<>();
+        return new DefaultKafkaProducerFactory<>(properties.buildProducerProperties(), new StringSerializer(), serializer);
+    }
+
+
+    @Bean
+    public KafkaTemplate<String, SearchLog> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/openvelog/openvelogbe/common/entity/SearchLog.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/entity/SearchLog.java
@@ -1,0 +1,47 @@
+package com.openvelog.openvelogbe.common.entity;
+
+import com.openvelog.openvelogbe.common.entity.enums.AgeRange;
+import com.openvelog.openvelogbe.common.entity.enums.Gender;
+import com.openvelog.openvelogbe.common.util.GetAgeRange;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity(name = "search_logs")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchLog extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String keyword;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private AgeRange ageRange;
+    private LocalDateTime searchDateTime;
+
+    public static SearchLog create(String keyword, Member member) {
+        SearchLogBuilder builder = SearchLog
+                .builder()
+                .keyword(keyword)
+                .searchDateTime(LocalDateTime.now());
+
+        if( member != null) {
+            builder
+                    .gender(member.getGender())
+                    .ageRange(GetAgeRange.getAge(member));
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/openvelog/openvelogbe/common/repository/SearchLogRepository.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/repository/SearchLogRepository.java
@@ -1,0 +1,16 @@
+package com.openvelog.openvelogbe.common.repository;
+
+import com.openvelog.openvelogbe.common.entity.KeywordRecord;
+import com.openvelog.openvelogbe.common.entity.SearchLog;
+import com.openvelog.openvelogbe.common.entity.enums.AgeRange;
+import com.openvelog.openvelogbe.common.entity.enums.Gender;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.persistence.Tuple;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
+}

--- a/src/main/java/com/openvelog/openvelogbe/common/util/GetAgeRange.java
+++ b/src/main/java/com/openvelog/openvelogbe/common/util/GetAgeRange.java
@@ -7,7 +7,7 @@ import com.openvelog.openvelogbe.common.entity.enums.Gender;
 import java.util.Calendar;
 
 public class GetAgeRange {
-    public AgeRange getAge(Member member)
+    public static AgeRange getAge(Member member)
     {
         AgeRange ageRange;
         Calendar current = Calendar.getInstance();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,49 +1,46 @@
 spring.profiles.active=prod
 
+#logging
+logging.level.com.openvelog.openvelogbe.common.util.KeywordRecordScheduler=INFO
+
+#swagger
+springdoc.swagger-ui.path=/docs
+
+# security
+jwt.secret.key=${JWT_SECRET_KEY}
+
+# database
 spring.jpa.hibernate.ddl-auto=update
-
-spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
-
 spring.datasource.driver-class-name=${DATABASE_DRIVER}
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.hikari.maximum-pool-size=40
 
+# redis
+spring.session.store-type=redis
 spring.redis.host=${REDIS_HOST}
 spring.redis.password=${REDIS_PASSWORD}
 spring.redis.port=${REDIS_PORT}
 
+# aws & s3
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto=false
-
 logging.level.com.amazonaws.SdkClientException=ERROR
 logging.level.com.amazonaws.util.EC2MetadataUtils=ERROR
 com.amazonaws.sdk.disableEc2Metadata=true
-
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
+#opensearch(elasticsearch)
 spring.elasticsearch.rest.uris=${OPEN_SEARCH_URIS}
 spring.elasticsearch.rest.username=${OPEN_SEARCH_USER_NAME}
 spring.elasticsearch.rest.password=${OPEN_SEARCH_PASSWORD}
-
 spring.elasticsearch.rest.max-conn-total=10
 spring.elasticsearch.rest.max-conn-per-route=5
-
-logging.level.com.openvelog.openvelogbe.common.util.KeywordRecordScheduler=INFO
-
-#spring.jpa.properties.hibernate.show_sql=true
-#spring.jpa.properties.hibernate.format_sql=true
-
-jwt.secret.key=${JWT_SECRET_KEY}
-
-springdoc.swagger-ui.path=/docs
-
-spring.datasource.hikari.maximum-pool-size=40
 
 #kafak consumer
 spring.kafka.consumer.bootstrap-servers=${KAFKA_SERVERS}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,15 @@ com.amazonaws.sdk.disableEc2Metadata=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
+spring.elasticsearch.rest.uris=${OPEN_SEARCH_URIS}
+spring.elasticsearch.rest.username=${OPEN_SEARCH_USER_NAME}
+spring.elasticsearch.rest.password=${OPEN_SEARCH_PASSWORD}
+
+spring.elasticsearch.rest.max-conn-total=10
+spring.elasticsearch.rest.max-conn-per-route=5
+
+logging.level.com.openvelog.openvelogbe.common.util.KeywordRecordScheduler=INFO
+
 #spring.jpa.properties.hibernate.show_sql=true
 #spring.jpa.properties.hibernate.format_sql=true
 
@@ -35,3 +44,13 @@ jwt.secret.key=${JWT_SECRET_KEY}
 springdoc.swagger-ui.path=/docs
 
 spring.datasource.hikari.maximum-pool-size=40
+
+#kafak consumer
+spring.kafka.consumer.bootstrap-servers=${KAFKA_SERVERS}
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.group-id=test-consumer-group
+spring.kafka.consumer.fetch-min-size=1024
+spring.kafka.consumer.fetch-max-wait=10000
+
+#kafak producer
+spring.kafka.producer.bootstrap-servers=localhost:9092

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,4 +53,4 @@ spring.kafka.consumer.fetch-min-size=1024
 spring.kafka.consumer.fetch-max-wait=10000
 
 #kafak producer
-spring.kafka.producer.bootstrap-servers=localhost:9092
+spring.kafka.producer.bootstrap-servers=${KAFKA_SERVERS}


### PR DESCRIPTION
feat:카프카 producer 서버 주소 설정 #153

feat:카프카 10초 혹은 1kb당 로그 저장하는 기능 추가 #153

카프카 설정 추가
KafkaTempleate<String, SearchLog> 설정
searchLog entity생성
키워드 검색시 해당 검색키워드 및 유저정보 producer처리
일정 batch마다 집계된 데이터 listener을 통해 consume처리
consume처리된 로그데이터를 mysql에 저장