### PR TITLE
fix: mysql database connection 경고 문구 고침 #174

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.datasource.driver-class-name=${DATABASE_DRIVER}
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
-spring.datasource.hikari.maximum-pool-size=40
+spring.datasource.hikari.maxLifetime=1800000
 
 # redis
 spring.session.store-type=redis


### PR DESCRIPTION
1. RDS의 connection timeout 시간보다 Hikari maxLifeTime이 적어서 발생했던 문제
2. RDS의 connection timeout을 35분으로, Hikari maxLifeTime을 30분으로 잡아서 해결